### PR TITLE
Show list of current file diagnostics on status bar label click

### DIFF
--- a/lsp/src/lsp-diagnostics.c
+++ b/lsp/src/lsp-diagnostics.c
@@ -636,7 +636,7 @@ void lsp_diagnostics_show_all(gboolean current_doc_only)
 
 		foreach_ptr_array(diag, i, diags)
 		{
-			if (current_doc_only && !utils_str_equal(doc->file_name, key))
+			if (current_doc_only && !utils_str_equal(doc->real_path, key))
 				continue;
 
 			item = g_new0(LspFileDiag, 1);

--- a/lsp/src/lsp-diagnostics.h
+++ b/lsp/src/lsp-diagnostics.h
@@ -31,7 +31,7 @@ void lsp_diagnostics_free(LspServer *srv);
 void lsp_diagnostics_show_calltip(gint pos);
 void lsp_diagnostics_hide_calltip(GeanyDocument *doc);
 
-void lsp_diagnostics_show_all(void);
+void lsp_diagnostics_show_all(gboolean current_doc_only);
 
 void lsp_diagnostics_received(LspServer *srv, GVariant* diags);
 void lsp_diagnostics_redraw(GeanyDocument *doc);

--- a/lsp/src/lsp-main.c
+++ b/lsp/src/lsp-main.c
@@ -1399,7 +1399,7 @@ static void invoke_kb(guint key_id, gint pos)
 			lsp_diagnostics_show_calltip(pos);
 			break;
 		case KB_SHOW_ALL_DIAGS:
-			lsp_diagnostics_show_all();
+			lsp_diagnostics_show_all(FALSE);
 			break;
 
 		case KB_FIND_REFERENCES:


### PR DESCRIPTION
I happily found the "issues" label on the statusbar and intuitively clicked on it to see what it found for the current document.

But nothing happened and here we go :).

I think since the status bar label displays the issue count of the current document, the opened list should also be filtered for the current document.

Maybe it's worth to add a keyboard shortcut as well for current document diagnostics but I'd leave this up to you.