### PR TITLE
Minor doc improvements

### DIFF
--- a/lsp/README
+++ b/lsp/README
@@ -247,9 +247,8 @@ Performance implications
 ========================
 
 To provide all the features, this plugin needs to react on various events
-like keystrokes, mouse movement, clicks, etc. and also communicate heavily
-with the LSP server to send the current document text and what kind of event
-happened.
+(e.g. keystrokes) and also communicates heavily with the LSP server to send the
+current document text and what kind of event happened.
 These additional tasks cause more CPU usage of the Geany process and especially
 the LSP server process, so they require also more power which might be
 relevant if you are using a laptop on battery power.

--- a/lsp/README
+++ b/lsp/README
@@ -88,7 +88,7 @@ Autocompletion
 Autocompletion works similarly to Geany's autocompletion feature. You can
 configure keybindings triggering the autocompletion popup.
 
-Function signagure
+Function signature
 ------------------
 
 When you type an open brace after a function name, the plugin displays the
@@ -240,8 +240,19 @@ checks and does not show any preview of the changes so it is best to use this
 feature only after committing all modified files so you can
 easily revert to a working state if needed. Since this is potentially a
 dangerous operation, to prevent accidental renames, the "Rename" button in the
-dialog is not selected by defalut and simply pressing enter just cancels the
+dialog is not selected by default and simply pressing enter just cancels the
 dialog.
+
+Performance implications
+========================
+
+To provide all the features, this plugin needs to react on various events
+like keystrokes, mouse movement, clicks, etc. and also communicate heavily
+with the LSP server to send the current document text and what kind of event
+happened.
+These additional tasks cause more CPU usage of the Geany process and especially
+the LSP server process, so they require also more power which might be
+relevant if you are using a laptop on battery power.
 
 Limitations
 ===========

--- a/lsp/data/lsp.conf
+++ b/lsp/data/lsp.conf
@@ -284,6 +284,8 @@ rpc_log=stdout
 # patterns assigned to this filetype in filetype_extensions.conf). The Nth
 # item in the list is always the LSP language ID and the (N+1)th item is a glob
 # pattern defining files for which the language ID is used
+# To find supported language IDs consult the documentation of the respective
+# LSP (or source code).
 lang_id_mappings=dummylanguage;*.dummy
 
 


### PR DESCRIPTION
I thought it might be useful to explain additional CPU usage by the plugin and especially the LSP which might be relevant if using a laptop without ac.

Also added a note in the default config that `languageID`s could maybe found in the LSP's documentation or at least source code.
I hope at some point there will be a better way than this :).